### PR TITLE
KMSDRM: Dumb Buffer page flip

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -383,6 +383,7 @@ KMSDRM_FBFromBO(_THIS, struct gbm_bo *bo)
 
     return fb_info;
 }
+#endif
 
 static void KMSDRM_FlipHandler(int fd, unsigned int frame, unsigned int sec, unsigned int usec, void *data)
 {
@@ -472,7 +473,7 @@ KMSDRM_WaitPageflip(_THIS, SDL_WindowData *windata)
 
     return SDL_TRUE;
 }
-#endif
+
 /* Given w, h and refresh rate, returns the closest DRM video mode
    available on the DRM connector of the display.
    We use the SDL mode list (which we filled in KMSDRM_GetDisplayModes)

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -112,6 +112,7 @@ typedef struct SDL_WindowData
     KMSDRM_DumbBuffer dumb_buffers[2];
     int front_buffer;
     int back_buffer;
+    SDL_bool set_crtc;
     SDL_Surface *framebuffer;
 
     SDL_bool waiting_for_flip;


### PR DESCRIPTION
Use `drmModePageFlip()` for better performance.

## Description

After initial `drmModeSetCrtc()`, continue calling `drmModePageFlip()` to issue async page flip requests so that the calling thread is unblocked and can do other work. Wait for page flip to complete on next `UpdateWindowFramebuffer` if still queued. Very similar to the code in `KMSDRM_GLES_SwapWindow()`.

As this is a PoC, I did not insist on rigorous error handling. Please let me know in case more is needed.

Tested with LZDoom and Crispy Doom on RISC-V MangoPi MQ-Pro SBC. This resulted in healthy 25% framerate improvement with 100% CPU utilization. Before this change the Set CRTC ioctl blocked and only 75% of CPU were utilized.